### PR TITLE
Clean up

### DIFF
--- a/vars/serviceBuildPipeline.groovy
+++ b/vars/serviceBuildPipeline.groovy
@@ -8,11 +8,8 @@ def call(body) {
     body()
 
     def kubeConfig = params.KUBE_CONFIG
-    def nameSpace = params.NAMESPACE
-    def mavenRepo = params.MAVEN_REPO
     def dockerRepo = params.DOCKER_URL
     def project
-    def lock = ""
     def buildVersion
     def scmVars
     def onlyMock = config.onlyMock ?: false
@@ -20,7 +17,6 @@ def call(body) {
 
     timestamps {
         withSlackNotificatons() {
-
             podTemplate(name: 'sa-secret',
                     serviceAccount: 'digitaldealer-serviceaccount',
                     envVars: [envVar(key: 'KUBERNETES_MASTER', value: 'https://kubernetes.default:443')],
@@ -93,12 +89,6 @@ def call(body) {
                         def prevVersion = ""
                         clientsK8sNode(clientsImage: 'stakater/pipeline-tools:1.11.0') {
                             stage("Download manifest") {
-                                echo "Fetching project ${project} version: ${buildVersion} for testing"
-                                withCredentials([string(credentialsId: 'nexus', variable: 'PWD')]) {
-                                    sh "wget https://ddadmin:${PWD}@${mavenRepo}/repository/maven-releases/com/scania/dd/${project}/${buildVersion}/${project}-${buildVersion}-kubernetes.yml -O service-deployment.yaml"
-                                }
-                                stash includes: 'service-deployment.yaml', name: 'manifest'
-
                                 container(name: 'clients') {
                                     echo "Save prev version"
                                     try {
@@ -116,146 +106,74 @@ def call(body) {
                                         }
                                     }
                                 }
-                                if (prevVersion != "") {
-                                    echo "Fetching project ${project} version: ${prevVersion} for rollback"
-                                    withCredentials([string(credentialsId: 'nexus', variable: 'PWD')]) {
-                                        sh "wget https://ddadmin:${PWD}@${mavenRepo}/repository/maven-releases/com/scania/dd/${project}/${prevVersion}/${project}-${prevVersion}-kubernetes.yml -O old-service-deployment.yaml"
-                                    }
-                                    stash includes: 'old-service-deployment.yaml', name: 'old-manifest'
-                                } else {
-                                    echo "Not fetching manifest for rollback, as there is no previous deployed version"
-                                }
                             }
                         }
 
-                        stage("Acquire lock on mock") {
-                            lock = tryLock("mock", env.JOB_NAME, (20 + 5) * 60, 4, buildVersion)
-                            while (lock == "") {
-                                echo "Waiting for lock"
-                                sleep 4
-                                lock = tryLock("mock", env.JOB_NAME, (20 + 5) * 60, 4, buildVersion)
-                            }
-                        }
-
-                        try {
-                            clientsK8sNode(clientsImage: 'stakater/pipeline-tools:1.11.0') {
-
+                        withLockOnMockEnvironment(lockName: "${env.JOB_NAME}-${env.BUILD_NUMBER}") {
+                            try {
                                 stage("Deploy to mock") {
-
                                     echo "Deploying project ${project} version: ${buildVersion}"
-                                    container(name: 'clients') {
-                                        unstash "manifest"
-                                        sh "kubectl apply  -n=mock -f service-deployment.yaml"
-                                        sh "kubectl rollout status deployment/${project} -n=mock --watch=true"
-                                    }
+                                    build job: "${project}-mock-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: buildVersion]]
                                 }
-                            }
 
-                            timeout(20) {
-                                mavenNode(mavenImage: 'stakater/chrome:67') {
-                                    container(name: 'maven') {
+                                timeout(20) {
+                                    mavenNode(mavenImage: 'stakater/chrome:67') {
+                                        container(name: 'maven') {
 
-                                        parallel SoapIntegrationTests: {
-                                            stage('Run soap integration tests') {
-                                                echo "Running soap integration tests on mock"
-                                                build job: "${soapITJobName}"
-                                            }
-                                        },
-                                                SystemTests: {
-                                                    try {
-                                                        stage("Run mock tests") {
-                                                            git url: 'https://gitlab.com/digitaldealer/systemtest2.git',
-                                                                    credentialsId: 'dd_ci',
-                                                                    branch: 'master'
-
-                                                            sh 'chmod +x mvnw'
-                                                            sh './mvnw clean test -Dbrowser=chrome -Dheadless=true -DsuiteXmlFile=smoketest-mock.xml'
-                                                        }
-                                                    } finally {
-                                                        zip zipFile: 'output.zip', dir: 'target', archive: true
-                                                        archiveArtifacts artifacts: 'target/screenshots/*', allowEmptyArchive: true
-                                                        junit 'target/surefire-reports/*.xml'
-                                                    }
+                                            parallel SoapIntegrationTests: {
+                                                stage('Run soap integration tests') {
+                                                    echo "Running soap integration tests on mock"
+                                                    build job: "${soapITJobName}"
                                                 }
+                                            },
+                                                    SystemTests: {
+                                                        try {
+                                                            stage("Run mock tests") {
+                                                                git url: 'https://gitlab.com/digitaldealer/systemtest2.git',
+                                                                        credentialsId: 'dd_ci',
+                                                                        branch: 'master'
+
+                                                                sh 'chmod +x mvnw'
+                                                                sh './mvnw clean test -Dbrowser=chrome -Dheadless=true -DsuiteXmlFile=smoketest-mock.xml'
+                                                            }
+                                                        } finally {
+                                                            zip zipFile: 'output.zip', dir: 'target', archive: true
+                                                            archiveArtifacts artifacts: 'target/screenshots/*', allowEmptyArchive: true
+                                                            junit 'target/surefire-reports/*.xml'
+                                                        }
+                                                    }
+                                        }
                                     }
                                 }
-                            }
-                        } catch (err) {
-                            if (prevVersion != "") {
-                                clientsK8sNode(clientsImage: 'stakater/pipeline-tools:1.11.0') {
-                                    echo "There were test failures. Rolling back mock"
-                                    container(name: 'clients') {
-                                        // Rolling back only rolls back the deployment, the service stays:
-                                        // sh "kubectl rollout undo deployment/${project} -n=mock"
-                                        // If we reapply an old manifest, the service will be correct, the
-                                        // replica set will be reused, but the deployment/replica set will
-                                        // have a new revision
-                                        unstash "old-manifest"
-                                        sh "kubectl apply  -n=mock -f old-service-deployment.yaml"
-                                        sh "kubectl rollout status deployment/${project} -n=mock --watch=true"
+                            } catch (err) {
+                                if (prevVersion != "") {
+                                    clientsK8sNode(clientsImage: 'stakater/pipeline-tools:1.11.0') {
+                                        echo "There were test failures. Rolling back mock"
+                                        build job: "${project}-mock-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: prevVersion]]
                                     }
+                                } else {
+                                    echo "There were test failures, but there was no previous version, not rolling back mock"
                                 }
-                            } else {
-                                echo "There were test failures, but there was no previous version, not rolling back mock"
+                                throw err
                             }
-                            throw err
-                        } finally {
-                            releaseLock(lock)
                         }
 
-                        if (onlyMock) {
-                            echo "onlyMock flag enabled, skipping deployment to dev and prod"
-                        } else {
-                            clientsK8sNode(clientsImage: 'stakater/pipeline-tools:1.11.0') {
+                        stage("Deploy to dev") {
+                            if (onlyMock) {
+                                echo "onlyMock flag enabled, skipping deployment to dev"
+                            } else {
+                                build job: "${project}-dev-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: buildVersion]]
+                            }
+                        }
 
-                                stage("Deploy to dev") {
-                                    echo "Deploying project ${project} version: ${buildVersion}"
-                                    container(name: 'clients') {
-                                        unstash "manifest"
-                                        sh "kubectl apply  -n=${nameSpace} -f service-deployment.yaml"
-                                        sh "kubectl rollout status deployment/${project} -n=${nameSpace} --watch=true"
-                                    }
-                                }
-
-                                stage('Deploy to prod') {
-                                    build job: "${project}-prod-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: buildVersion]]
-                                }
+                        stage('Deploy to prod') {
+                            if (onlyMock) {
+                                echo "onlyMock flag enabled, skipping deployment to prod"
+                            } else {
+                                build job: "${project}-prod-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: buildVersion]]
                             }
                         }
                     }
         }
     }
 }
-
-private String tryLock(lock, job_name, activeWait, lockWait, buildVersion) {
-    def url = new URL("http://restful-distributed-lock-manager.tools:8080/locks/${lock}")
-    def conn = url.openConnection()
-    conn.setDoOutput(true)
-    def writer = new OutputStreamWriter(conn.getOutputStream())
-    writer.write("{\"title\": \"${job_name}-${buildVersion}\", \"lifetime\": ${activeWait}, \"wait\": ${lockWait}}")
-    writer.flush()
-    writer.close()
-
-    def responseCode = conn.getResponseCode()
-    if (responseCode == 201) {
-        def lockUrl = conn.getHeaderField("Location")
-        echo "Acquired ${lockUrl}"
-        return lockUrl
-    } else if (responseCode != 408) {
-        echo "Something went wrong when locking: ${responseCode}"
-    }
-    echo "Did not get a lock"
-    return ""
-}
-
-private void releaseLock(lockUrl) {
-    echo "Releasing ${lockUrl}"
-    def url = new URL(lockUrl)
-    def conn = url.openConnection()
-    conn.setRequestMethod("DELETE")
-    def responseCode = conn.getResponseCode()
-    if (responseCode != 204) {
-        echo "Something went wrong when releaseing the lock: ${responseCode}"
-    }
-}
-

--- a/vars/serviceBuildPipeline.groovy
+++ b/vars/serviceBuildPipeline.groovy
@@ -112,7 +112,6 @@ def call(body) {
                         withLockOnMockEnvironment(lockName: "${env.JOB_NAME}-${env.BUILD_NUMBER}") {
                             try {
                                 stage("Deploy to mock") {
-                                    echo "Deploying project ${project} version: ${buildVersion}"
                                     build job: "${project}-mock-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: buildVersion]]
                                 }
 
@@ -147,10 +146,8 @@ def call(body) {
                                 }
                             } catch (err) {
                                 if (prevVersion != "") {
-                                    clientsK8sNode(clientsImage: 'stakater/pipeline-tools:1.11.0') {
-                                        echo "There were test failures. Rolling back mock"
-                                        build job: "${project}-mock-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: prevVersion]]
-                                    }
+                                    echo "There were test failures. Rolling back mock"
+                                    build job: "${project}-mock-deploy", parameters: [[$class: 'StringParameterValue', name: 'VERSION', value: prevVersion]]
                                 } else {
                                     echo "There were test failures, but there was no previous version, not rolling back mock"
                                 }


### PR DESCRIPTION
Remove duplicated code -- no real change in flow
 - instead of implementing locking we reuse the with function: the two helper function and the lock variable can be removed
 - instead of deploying to mock, we call the deploy job: we don't need to download manifests anymore
 - move only mock check to the stage: if set, we still have the stages, thus we don't lose the history